### PR TITLE
Add flag to enable bitmanip ext support

### DIFF
--- a/src/flags/flag-definitions.h
+++ b/src/flags/flag-definitions.h
@@ -1905,6 +1905,9 @@ DEFINE_BOOL(riscv_constant_pool, true,
 
 DEFINE_BOOL(riscv_c_extension, false,
             "enable compressed extension isa variant (RISCV only)")
+
+DEFINE_BOOL(riscv_bitmanip, false,
+            "enable bitmanip extension instructions")
 #endif
 
 // Controlling source positions for Torque/CSA code.


### PR DESCRIPTION
Disabled by default for now.

Usage:
```cpp
#include "src/flags/flags.h"

if (v8_flags.riscv_bitmanip) {
  printf("Enabled!");
}
```

Fixes #11